### PR TITLE
Add missing edit param

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,3 +28,4 @@ enableRobotsTXT = true
 [params]
    geekdocLogo = "seedling_1f331.png"
    geekdocRepo = "https://github.com/merelinux/wiki"
+   geekdocEditPath = "edit/main/"


### PR DESCRIPTION
Another param was needed in order to allow direct edit links to work.